### PR TITLE
Fixes incorrect merge of CServices when configuring a system at startup

### DIFF
--- a/forms/hateoasForms.go
+++ b/forms/hateoasForms.go
@@ -30,6 +30,7 @@ package forms
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -63,10 +64,11 @@ func SysHateoas(w http.ResponseWriter, req *http.Request, sys components.System)
 	text = "</ul> having the following services:<ul>"
 	w.Write([]byte(text))
 	servicesList := getServicesList(getFirstAsset(*assetList)[0])
+	sort.Slice(servicesList, func(i, j int) bool { return servicesList[i].Definition < servicesList[j].Definition })
 	for _, service := range servicesList {
 		metaservice := ""
-		for key, values := range service.Details {
-			metaservice += key + ": " + fmt.Sprintf("%v", values) + " "
+		for _, key := range sortMapKeys(service.Details) {
+			metaservice += key + ": " + fmt.Sprintf("%v", service.Details[key]) + " "
 		}
 		serviceURI := "<li><b>" + service.Definition + "</b> with details: " + metaservice + "</li>"
 		w.Write([]byte(serviceURI))
@@ -155,4 +157,14 @@ func getServicesList(uat components.UnitAsset) []components.Service {
 		serviceList = append(serviceList, *services[s])
 	}
 	return serviceList
+}
+
+// sortMapKeys returns a sorted list of string keys from a map (of any type)
+func sortMapKeys[T any](m map[string]T) []string {
+	var list []string
+	for k := range m {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return list
 }

--- a/usecases/configuration.go
+++ b/usecases/configuration.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/sdoque/mbaigo/components"
 )
@@ -155,6 +156,9 @@ func Configure(sys *components.System) ([]json.RawMessage, []components.Service,
 	}
 
 	// update the services (e.g., re-registration period)
+	// (the slices might have their order jumbled, so have to sort them so the indices matches correctly)
+	sortServicesList(configurationIn.CServices)
+	sortServicesList(originalSs)
 	for i := range configurationIn.CServices {
 		(configurationIn.CServices)[i].Merge(&originalSs[i])
 	}
@@ -181,4 +185,9 @@ func getServicesList(uat components.UnitAsset) []components.Service {
 		serviceList = append(serviceList, *services[s])
 	}
 	return serviceList
+}
+
+// sortServicesList sorts a list of services, based on the definition of each service
+func sortServicesList(list []components.Service) {
+	sort.Slice(list, func(i, j int) bool { return list[i].Definition < list[j].Definition })
 }


### PR DESCRIPTION
Solves the problem with jumbled units for the services on a system's documentation web page, as initially observed by @gabaxh and/or @SimonPergel.

Some kind of OCD compelled me to also sort the list in question.