### PR TITLE
Allowing to configure host's IP addresses

### DIFF
--- a/usecases/configuration.go
+++ b/usecases/configuration.go
@@ -42,22 +42,24 @@ type ConfigurableAsset struct {
 
 // templateOut is the struct used to prepare the systemconfig.json file
 type templateOut struct {
-	CName      string                  `json:"systemname"`
-	LocalCloud string                  `json:"localcloud,omitempty"`
-	Assets     []ConfigurableAsset     `json:"unit_assets"`
-	Protocols  map[string]int          `json:"protocolsNports"`
-	CCoreS     []components.CoreSystem `json:"coreSystems"`
+	CName       string                  `json:"systemname"`
+	LocalCloud  string                  `json:"localcloud,omitempty"`
+	IPAddresses []string                `json:"ipAddresses"`
+	Assets      []ConfigurableAsset     `json:"unit_assets"`
+	Protocols   map[string]int          `json:"protocolsNports"`
+	CCoreS      []components.CoreSystem `json:"coreSystems"`
 }
 
 // configFileIn is used to extract out the information of the systemconfig.json file
 // Since it does not know about the details of the Thing, it does not unmarsahll this
 // information
 type configFileIn struct {
-	CName      string                  `json:"systemname"`
-	LocalCloud string                  `json:"localcloud,omitempty"`
-	Protocols  map[string]int          `json:"protocolsNports"`
-	CCoreS     []components.CoreSystem `json:"coreSystems"`
-	Resources  []json.RawMessage       `json:"unit_assets"`
+	CName       string                  `json:"systemname"`
+	LocalCloud  string                  `json:"localcloud,omitempty"`
+	IPAddresses []string                `json:"ipAddresses"`
+	Protocols   map[string]int          `json:"protocolsNports"`
+	CCoreS      []components.CoreSystem `json:"coreSystems"`
+	Resources   []json.RawMessage       `json:"unit_assets"`
 }
 
 var ErrNewConfig = errors.New("new config file was created")
@@ -99,6 +101,7 @@ func setupDefaultConfig(sys *components.System) (defaultConfig templateOut, err 
 			break
 		}
 	}
+	defaultConfig.IPAddresses = sys.Husk.Host.IPAddresses
 	defaultConfig.Protocols = sys.Husk.ProtoPort
 	defaultConfig.Assets = []ConfigurableAsset{confAsset} // this is a list of unit assets
 
@@ -175,6 +178,10 @@ func Configure(sys *components.System) ([]json.RawMessage, error) {
 	}
 
 	sys.Name = configurationIn.CName
+	// Restore IP addresses from config, allowing operators to limit which address is used.
+	if len(configurationIn.IPAddresses) > 0 {
+		sys.Husk.Host.IPAddresses = configurationIn.IPAddresses
+	}
 	// If the systemconfig file has a LocalCloud defined, add it to the system details
 	if configurationIn.LocalCloud != "" {
 		if sys.Husk.Details == nil {

--- a/usecases/configuration_test.go
+++ b/usecases/configuration_test.go
@@ -83,6 +83,7 @@ func createConfigHasTraits(sys *components.System) (err error) {
 
 	defaultConfig.CCoreS = []components.CoreSystem{leadingRegistrar, orchestrator, ca, maitreD}
 	defaultConfig.CName = sys.Name
+	defaultConfig.IPAddresses = sys.Husk.Host.IPAddresses
 	defaultConfig.Protocols = sys.Husk.ProtoPort
 	defaultConfigFile, err := os.Create("systemconfig.json")
 	if err != nil {
@@ -143,6 +144,7 @@ func createConfigNoTraits(sys *components.System, assetAmount int) (err error) {
 
 	defaultConfig.CCoreS = []components.CoreSystem{leadingRegistrar, orchestrator, ca, maitreD}
 	defaultConfig.CName = sys.Name
+	defaultConfig.IPAddresses = sys.Husk.Host.IPAddresses
 	defaultConfig.Protocols = sys.Husk.ProtoPort
 	defaultConfigFile, err := os.Create("systemconfig.json")
 	if err != nil {
@@ -157,6 +159,33 @@ func createConfigNoTraits(sys *components.System, assetAmount int) (err error) {
 		return fmt.Errorf("jsonEncode: %v", err)
 	}
 	return
+}
+
+// createConfigEmptyIPs writes a config file with an explicit empty ipAddresses
+// list, simulating an old config created before IP persistence was added.
+func createConfigEmptyIPs(sys *components.System) error {
+	type minimalConfig struct {
+		CName     string                  `json:"systemname"`
+		Protocols map[string]int          `json:"protocolsNports"`
+		CCoreS    []components.CoreSystem `json:"coreSystems"`
+		Assets    []ConfigurableAsset     `json:"unit_assets"`
+	}
+	cfg := minimalConfig{
+		CName:     sys.Name,
+		Protocols: sys.Husk.ProtoPort,
+		CCoreS: []components.CoreSystem{
+			{Name: "serviceregistrar", Url: "http://localhost:20102/serviceregistrar/registry"},
+		},
+		Assets: []ConfigurableAsset{{Name: "testUnitAsset"}},
+	}
+	f, err := os.Create("systemconfig.json")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "    ")
+	return enc.Encode(cfg)
 }
 
 // --------------------------------------------------------- //
@@ -310,6 +339,60 @@ func TestConfigure(t *testing.T) {
 			t.Errorf("failed to remove 'systemconfig.json' in testcase '%s'", testCase.testCase)
 		}
 	}
+}
+
+// TestConfigureIPAddresses verifies that IP addresses are correctly persisted
+// and restored through the config file.
+func TestConfigureIPAddresses(t *testing.T) {
+	t.Run("IP addresses from config override discovered IPs", func(t *testing.T) {
+		testSys := createTestSystem(false)
+
+		// Write a config that includes the system's discovered IPs.
+		if err := createConfigNoTraits(&testSys, 1); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer cleanup()
+
+		// Simulate a network change by replacing the in-memory IPs with a sentinel value.
+		testSys.Husk.Host.IPAddresses = []string{"9.9.9.9"}
+
+		if _, err := Configure(&testSys); err != nil {
+			t.Fatalf("Configure returned unexpected error: %v", err)
+		}
+
+		// The IPs should have been restored from the config, not the sentinel.
+		for _, ip := range testSys.Husk.Host.IPAddresses {
+			if ip == "9.9.9.9" {
+				t.Error("expected config IPs to override discovered IPs, but sentinel value survived")
+			}
+		}
+	})
+
+	t.Run("Config without ipAddresses keeps discovered IPs", func(t *testing.T) {
+		testSys := createTestSystem(false)
+
+		// Write a config that has no ipAddresses field (old-style config).
+		if err := createConfigEmptyIPs(&testSys); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer cleanup()
+
+		discovered := make([]string, len(testSys.Husk.Host.IPAddresses))
+		copy(discovered, testSys.Husk.Host.IPAddresses)
+
+		if _, err := Configure(&testSys); err != nil && err != ErrNewConfig {
+			t.Fatalf("Configure returned unexpected error: %v", err)
+		}
+
+		if len(testSys.Husk.Host.IPAddresses) != len(discovered) {
+			t.Errorf("expected %d IPs, got %d", len(discovered), len(testSys.Husk.Host.IPAddresses))
+		}
+		for i, ip := range testSys.Husk.Host.IPAddresses {
+			if ip != discovered[i] {
+				t.Errorf("IP[%d]: expected %s, got %s", i, discovered[i], ip)
+			}
+		}
+	})
 }
 
 // --------------------------------------------------------- //


### PR DESCRIPTION
There are times we want to not use certain IP addresses although they exist. Now, we can remove them in the configuration files.
This also allows to have the systems start up with the host even if the IP address is not yet up.