### PR TITLE
Non-blocking RequestCertificate; memory-only system keys; HTTPS waits…

### DIFF
--- a/components/husk.go
+++ b/components/husk.go
@@ -44,6 +44,12 @@ type Husk struct {
 	InfoLink      string              `json:"onlineDocumentation"`
 	Messengers    map[string]int      `json:"-"` // list of messenger systems
 
+	// CertReady is closed once a valid certificate is in Certificate and TLS
+	// has been configured on http.DefaultClient. Lazily initialised by
+	// usecases.RequestCertificate / SetoutServers so existing system mains
+	// do not need to construct it; consumers waiting for the cert (e.g. the
+	// HTTPS server bind) read from it via select with sys.Ctx.Done().
+	CertReady chan struct{} `json:"-"`
 }
 
 // SProtocols returns a slice of supported protocols (i.e., those not configured with 0)

--- a/usecases/authentication.go
+++ b/usecases/authentication.go
@@ -39,33 +39,63 @@ import (
 	"github.com/sdoque/mbaigo/components"
 )
 
-// RequestCertificate generates the system's public key and a certificate signing request to be sent to the CA.
-// It is a no-op when no HTTPS port is configured. On subsequent startups it reuses the certificate saved
-// to disk from the previous enrollment, requesting a new one only when the saved cert is missing or
-// within 24 hours of expiry. If the CA is unreachable it retries every minute until it succeeds or
-// the system context is cancelled.
+// EnsureCertReady returns the system's CertReady channel, initialising it on
+// first call. Safe for concurrent use: either RequestCertificate or
+// SetoutServers may be the first to need it.
+func EnsureCertReady(sys *components.System) chan struct{} {
+	sys.Mutex.Lock()
+	defer sys.Mutex.Unlock()
+	if sys.Husk.CertReady == nil {
+		sys.Husk.CertReady = make(chan struct{})
+	}
+	return sys.Husk.CertReady
+}
+
+// RequestCertificate kicks off TLS-certificate acquisition for the system.
+// It is non-blocking: a goroutine generates a fresh ECDSA key pair in
+// memory, builds a CSR, and retries enrolment with the CA until success or
+// context cancellation. CertReady is closed when the cert lands on
+// sys.Husk.Certificate and TLS is installed on http.DefaultClient.
+//
+// **Memory-only keys.** Application systems do not persist their private
+// keys to disk. A fresh key is generated on every startup and the resulting
+// cert lives only for the lifetime of the process. Consequences:
+//
+//   - The system's identity in the cloud is the *running binary* (whitelist
+//     hash + attestation), not a long-lived on-disk credential. The cert is
+//     the cryptographic instantiation of that identity, and ends with the
+//     process.
+//   - There is no filesystem attack surface for the key. An attacker who
+//     compromises the host as the system's user cannot extract the key
+//     without entering the running process's address space.
+//   - Revocation by whitelist edit takes effect at next restart with no
+//     stale cached cert outliving the operator's authorisation.
+//   - The CA must be reachable for the system to reach a TLS-enabled state.
+//     The HTTP server (per SetoutServers) starts immediately regardless,
+//     so plain-HTTP services remain available during a CA outage.
+//
+// The CA itself is the necessary exception: it persists its root key on
+// disk because the entire trust chain depends on its identity surviving
+// restarts. See systems/ca/thing.go.
 func RequestCertificate(sys *components.System) {
-	// Nothing to do when HTTPS is not enabled.
 	if sys.Husk.ProtoPort["https"] == 0 {
 		return
 	}
+	certReady := EnsureCertReady(sys)
+	go acquireCertificate(sys, certReady)
+}
 
-	certFile := sys.Name + "_certificate.pem"
-	keyFile := sys.Name + "_private_key.pem"
-
-	// Reuse a previously issued certificate if it is still valid.
-	if key, certPEM, err := loadSystemCertificate(certFile, keyFile); err == nil {
-		log.Printf("reusing existing certificate for %s\n", sys.Name)
-		sys.Husk.Pkey = key
-		sys.Husk.Certificate = certPEM
-		installTLSConfig(sys)
-		return
-	}
-
-	// Generate ECDSA Private Key
+// acquireCertificate generates a key pair in memory, builds a CSR, and
+// retries enrolment with the CA until success or context cancellation. On
+// success it installs TLS on http.DefaultClient and closes certReady so
+// consumers can proceed. On context cancellation, certReady is left open:
+// any consumer waiting on it should also select on sys.Ctx.Done() to avoid
+// a permanent block.
+func acquireCertificate(sys *components.System, certReady chan struct{}) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		log.Fatalf("Failed to generate private key: %v\n", err)
+		log.Printf("failed to generate private key for %s: %v", sys.Name, err)
+		return
 	}
 	sys.Husk.Pkey = privateKey
 
@@ -86,13 +116,11 @@ func RequestCertificate(sys *components.System) {
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, privateKey)
 	if err != nil {
-		log.Fatalf("Failed to create CSR: %v\n", err)
+		log.Printf("failed to create CSR for %s: %v", sys.Name, err)
+		return
 	}
-
-	// Encode the CSR to PEM format
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
 
-	// Send the CSR to the CA, retrying every minute until it succeeds or the context is cancelled.
 	var response string
 	for {
 		response, err = sendCSR(sys, csrPEM)
@@ -108,15 +136,9 @@ func RequestCertificate(sys *components.System) {
 		}
 	}
 
-	// Save the received certificate and private key to disk for future restarts.
-	if err := saveSystemCertificate(certFile, keyFile, response, privateKey); err != nil {
-		log.Printf("warning: could not save certificate to disk: %v\n", err)
-	}
-
-	// Store the received certificate
 	sys.Husk.Certificate = response
-
 	installTLSConfig(sys)
+	close(certReady)
 }
 
 // installTLSConfig fetches the CA certificate, builds the TLS configuration from the system's
@@ -272,50 +294,3 @@ func prepareClientCertificate(certPEM string, privateKey *ecdsa.PrivateKey) (tls
 	return clientCert, nil
 }
 
-// loadSystemCertificate reads the certificate and private key from disk and returns them if the
-// certificate is valid and not expiring within the next 24 hours.
-func loadSystemCertificate(certFile, keyFile string) (*ecdsa.PrivateKey, string, error) {
-	certPEMBytes, err := os.ReadFile(certFile) // #nosec G304 — path is derived from sys.Name, a compile-time constant, not user input
-	if err != nil {
-		return nil, "", err
-	}
-	keyPEMBytes, err := os.ReadFile(keyFile) // #nosec G304 — same rationale as above
-	if err != nil {
-		return nil, "", err
-	}
-
-	certBlock, _ := pem.Decode(certPEMBytes)
-	if certBlock == nil {
-		return nil, "", fmt.Errorf("failed to decode certificate PEM")
-	}
-	cert, err := x509.ParseCertificate(certBlock.Bytes)
-	if err != nil {
-		return nil, "", err
-	}
-	if time.Now().After(cert.NotAfter.Add(-24 * time.Hour)) {
-		return nil, "", fmt.Errorf("certificate expires at %s, requesting a new one", cert.NotAfter)
-	}
-
-	keyBlock, _ := pem.Decode(keyPEMBytes)
-	if keyBlock == nil {
-		return nil, "", fmt.Errorf("failed to decode key PEM")
-	}
-	privateKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return privateKey, string(certPEMBytes), nil
-}
-
-// saveSystemCertificate writes the signed certificate and private key to disk.
-func saveSystemCertificate(certFile, keyFile, certPEM string, privateKey *ecdsa.PrivateKey) error {
-	if err := os.WriteFile(certFile, []byte(certPEM), 0600); err != nil {
-		return err
-	}
-	keyPEM, err := encodeECDSAPrivateKeyToPEM(privateKey)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(keyFile, keyPEM, 0600)
-}

--- a/usecases/authentication_test.go
+++ b/usecases/authentication_test.go
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Synecdoque
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, subject to the following conditions:
+ *
+ * The software is licensed under the MIT License. See the LICENSE file in this repository for details.
+ *
+ * Contributors:
+ *   Jan A. van Deventer, Luleå - initial implementation
+ ***************************************************************************SDG*/
+
+package usecases
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sdoque/mbaigo/components"
+)
+
+// EnsureCertReady is the gate between RequestCertificate (the producer that
+// closes the channel once a cert is in place) and SetoutServers (the consumer
+// that waits before binding HTTPS). The same channel must be returned to all
+// callers regardless of who arrives first or how many goroutines call
+// concurrently.
+
+func TestEnsureCertReadyIdempotent(t *testing.T) {
+	sys := &components.System{
+		Husk:  &components.Husk{},
+		Mutex: &sync.Mutex{},
+	}
+
+	first := EnsureCertReady(sys)
+	if first == nil {
+		t.Fatal("EnsureCertReady returned nil on first call")
+	}
+
+	second := EnsureCertReady(sys)
+	if second != first {
+		t.Errorf("EnsureCertReady returned a different channel on second call: %p vs %p", second, first)
+	}
+}
+
+func TestEnsureCertReadyConcurrent(t *testing.T) {
+	sys := &components.System{
+		Husk:  &components.Husk{},
+		Mutex: &sync.Mutex{},
+	}
+
+	const goroutines = 50
+	results := make(chan chan struct{}, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- EnsureCertReady(sys)
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var first chan struct{}
+	for ch := range results {
+		if first == nil {
+			first = ch
+			continue
+		}
+		if ch != first {
+			t.Fatal("concurrent calls returned different channels")
+		}
+	}
+}
+
+// CertReady's value is significant: a closed channel is the signal that the
+// cert is ready. Reading from a closed channel returns immediately.
+func TestEnsureCertReadyClosesOnSignal(t *testing.T) {
+	sys := &components.System{
+		Husk:  &components.Husk{},
+		Mutex: &sync.Mutex{},
+	}
+
+	ch := EnsureCertReady(sys)
+
+	// Channel must be open initially.
+	select {
+	case <-ch:
+		t.Fatal("CertReady channel was closed without anyone closing it")
+	default:
+	}
+
+	// Closing the channel must be observable through subsequent EnsureCertReady calls.
+	close(ch)
+	again := EnsureCertReady(sys)
+	select {
+	case <-again:
+		// success
+	default:
+		t.Fatal("EnsureCertReady returned a channel that did not reflect the close")
+	}
+}

--- a/usecases/servers_handlers.go
+++ b/usecases/servers_handlers.go
@@ -52,57 +52,23 @@ func SetoutServers(sys *components.System) error {
 	// how to handle requests to the servers
 	http.HandleFunc("/"+sys.Name+"/", createResourceHandler(sys))
 
-	// if an HTTPS server is required (configuration file) and the system as a signed certificate, set up and start an HTTPS server
-	if httpsPort != 0 && sys.Husk.Certificate != "" {
-		// Encode the ECDSA private key to PEM format
-		privateKeyPEM, err := encodeECDSAPrivateKeyToPEM(sys.Husk.Pkey)
-		if err != nil {
-			return fmt.Errorf("encoding private key: %w", err)
-		}
-
-		// Load the certificate and key
-		cert, err := tls.X509KeyPair([]byte(sys.Husk.Certificate), privateKeyPEM)
-		if err != nil {
-			return fmt.Errorf("parsing certificate/private key: %w", err)
-		}
-
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(sys.Husk.CA_cert))
-
-		// create a TLS config with the certificate and CA pool
-		tlsConfig := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
-		}
-
-		// Create a HTTPS server with the TLS config
-		httpsServer := &http.Server{
-			Addr:         ":" + strconv.Itoa(httpsPort),
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 60 * time.Second,
-			TLSConfig:    tlsConfig,
-			Handler:      nil,
-		}
-
-		// Initiate graceful shutdown on signal reception
+	// HTTPS bind is deferred until the certificate is ready. We start a
+	// goroutine that waits on CertReady (closed by RequestCertificate when
+	// the cert is in place) and then binds the TLS server. The HTTP server
+	// below is unaffected — it starts immediately, so the system is
+	// reachable on its plain-HTTP services even while cert acquisition is
+	// still in progress.
+	if httpsPort != 0 {
+		certReady := EnsureCertReady(sys)
 		go func() {
-			<-sys.Ctx.Done()
-			if err := httpsServer.Shutdown(context.Background()); err != nil {
-				log.Printf("Error during shutdown: %v", err)
+			select {
+			case <-certReady:
+				// proceed to bind HTTPS
+			case <-sys.Ctx.Done():
+				return
 			}
-		}()
-
-		// Inform the user how to access the system's web server (black box documentation)
-		httpsURL := "https://" + sys.Husk.Host.IPAddresses[0] + ":" + strconv.Itoa(httpsPort) + "/" + sys.Name
-		log.Printf("The system %s is up with its web server available at %s\n", sys.Name, httpsURL)
-
-		// Start and monitor the server
-		go func() {
-			err := httpsServer.ListenAndServeTLS("", "")
-			if err != nil && err != http.ErrServerClosed {
-				log.Fatalf("Error from web server: %v\n", err)
+			if err := startHTTPSServer(sys, httpsPort); err != nil {
+				log.Printf("HTTPS server failed to start: %v", err)
 			}
 		}()
 	}
@@ -138,6 +104,56 @@ func SetoutServers(sys *components.System) error {
 		}()
 	}
 
+	return nil
+}
+
+// startHTTPSServer builds the TLS configuration from the system's now-ready
+// certificate and binds the HTTPS server on the given port. Called by
+// SetoutServers from a goroutine that waited on CertReady, so the cert is
+// guaranteed to be in place by the time we reach here.
+func startHTTPSServer(sys *components.System, httpsPort int) error {
+	privateKeyPEM, err := encodeECDSAPrivateKeyToPEM(sys.Husk.Pkey)
+	if err != nil {
+		return fmt.Errorf("encoding private key: %w", err)
+	}
+
+	cert, err := tls.X509KeyPair([]byte(sys.Husk.Certificate), privateKeyPEM)
+	if err != nil {
+		return fmt.Errorf("parsing certificate/private key: %w", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(sys.Husk.CA_cert))
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	httpsServer := &http.Server{
+		Addr:         ":" + strconv.Itoa(httpsPort),
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		TLSConfig:    tlsConfig,
+		Handler:      nil,
+	}
+
+	// Graceful shutdown on context cancellation.
+	go func() {
+		<-sys.Ctx.Done()
+		if err := httpsServer.Shutdown(context.Background()); err != nil {
+			log.Printf("Error during HTTPS shutdown: %v", err)
+		}
+	}()
+
+	httpsURL := "https://" + sys.Husk.Host.IPAddresses[0] + ":" + strconv.Itoa(httpsPort) + "/" + sys.Name
+	log.Printf("The system %s is up with its web server available at %s\n", sys.Name, httpsURL)
+
+	if err := httpsServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("HTTPS server: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
… on CertReady